### PR TITLE
Use desktop-file-utils from runtime

### DIFF
--- a/page.codeberg.JakobDev.jdDesktopEntryEdit.yaml
+++ b/page.codeberg.JakobDev.jdDesktopEntryEdit.yaml
@@ -20,17 +20,6 @@ finish-args:
 modules:
   - python3-modules.yaml
 
-  - name: desktop-file-utils
-    buildsystem: meson
-    sources:
-      - type: archive
-        url: https://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.28.tar.xz
-        sha256: 4401d4e231d842c2de8242395a74a395ca468cd96f5f610d822df33594898a70
-        x-checker-data:
-          type: anitya
-          project-id: 421
-          url-template: https://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-$version.tar.xz
-
   - name: jdDesktopEntryEdit
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
KDE runtime version 6.10 appears to contain the **desktop-file-utils** module.


```
grep desktop-file -a5 /usr/manifest-base-1.json 

"name": "components/desktop-file-utils.bst",
"product": "desktop-file-utils",
"version": "0.28"
"url": "https://gitlab.freedesktop.org/xdg/desktop-file-utils.git",
```